### PR TITLE
fix: npm run chore:update-deps error fix (#3250)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "bootstrap": "lerna bootstrap",
     "build": "father-build",
     "changelog": "lerna-changelog",
-    "chore:update-deps": "./scripts/update_deps.sh",
+    "chore:update-deps": "sh ./scripts/reinstall_deps.sh",
     "clean": "lerna clean -y",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "debug": "./packages/umi-test/bin/umi-test.js",


### PR DESCRIPTION
1. update_deps.sh not exist. 
2. use `sh ./scripts/reinstall_deps.sh` to run command on git-bash in windows.

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
