### PR TITLE
fix: import umi-ui fail error (#3252)

### DIFF
--- a/packages/umi-ui/package.json
+++ b/packages/umi-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "umi-ui",
   "version": "1.0.6",
-  "main": "./lib/index.js",
+  "main": "./lib/UmiUI.js",
   "files": [
     "lib",
     "client/dist",


### PR DESCRIPTION
* fix: npm run chore:update-deps error fix

1. update_deps.sh not exist. 
2. use `sh ./scripts/reinstall_deps.sh` to run command on git-bash in windows.

* fix: import umi-ui fail error

require("umi-ui") Error: Cannot find module 'umi-ui'

<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/umi/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/umi/ISSUE_URL
